### PR TITLE
add screenshot auto capture functionality for pretraining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ vizdoom.ini
 
 # Data generated from pytest
 save_videos*/
+_renders/
+renders/


### PR DESCRIPTION
# Description

The Car-Racing env now takes screenshots in human-render mode. It labels the screenshots with `frame-<num>-<direction>.png` with num auto-incrementing per capture and direction being left, right or straight.

Fixes # (issue)

## Type of change
![demo](https://github.com/user-attachments/assets/86c8f36a-2bd5-4f8f-a2c4-a13662fef2c3)

new feature

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update